### PR TITLE
Add bpm to song info

### DIFF
--- a/src/show_song.rs
+++ b/src/show_song.rs
@@ -248,6 +248,7 @@ impl<'a> Display for SongInfoDisplay<'a> {
 
         writeln!(f, "Version              : {}", s.version)?;
         writeln!(f, "Name                 : {}", s.name)?;
+        writeln!(f, "BPM                  : {}", s.tempo)?;
 
         let instr_count = s.instruments.iter()
             .fold(


### PR DESCRIPTION
Simple addition - just grabs the song.tempo from the parser and adds it to the info display